### PR TITLE
Optional level summary

### DIFF
--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -53,12 +53,20 @@ export function parseMdContent(md: string): TutorialFrame | never {
     const stepMatch = section.match(stepRegex);
 
     if (levelMatch) {
+      const {
+        levelId,
+        levelTitle,
+        levelSummary,
+        levelContent,
+      } = levelMatch.groups;
       const level = {
-        [levelMatch.groups.levelId]: {
-          id: levelMatch.groups.levelId,
-          title: levelMatch.groups.levelTitle,
-          summary: levelMatch.groups.levelSummary.trim(),
-          content: levelMatch.groups.levelContent.trim(),
+        [levelId]: {
+          id: levelId,
+          title: levelTitle,
+          summary: levelSummary
+            ? levelSummary.trim()
+            : _.truncate(levelContent, { length: 80, omission: "..." }),
+          content: levelContent.trim(),
         },
       };
 

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -88,4 +88,60 @@ levels:
     };
     expect(result.levels).toEqual(expected.levels);
   });
+
+  it("should parse a level with no level description", () => {
+    const md = `# Title
+    
+Description.
+
+## L1 Put Level's title here
+
+Some text that becomes the summary
+`;
+
+    const yaml = `version: "0.1.0"
+levels:
+- id: L1
+`;
+    const result = parse(md, yaml);
+    const expected = {
+      levels: [
+        {
+          id: "L1",
+          title: "Put Level's title here",
+          summary: "Some text that becomes the summary",
+          content: "Some text that becomes the summary",
+        },
+      ],
+    };
+    expect(result.levels).toEqual(expected.levels);
+  });
+
+  it("should truncate a level description", () => {
+    const md = `# Title
+    
+Description.
+
+## L1 Put Level's title here
+
+Some text that becomes the summary and goes beyond the maximum length of 80 so that it gets truncated at the end
+`;
+
+    const yaml = `version: "0.1.0"
+levels:
+- id: L1
+`;
+    const result = parse(md, yaml);
+    const expected = {
+      levels: [
+        {
+          id: "L1",
+          title: "Put Level's title here",
+          summary: "Some text that becomes the summary",
+          content: "Some text that becomes the summary",
+        },
+      ],
+    };
+    expect(result.levels[0].summary).toMatch(/\.\.\.$/);
+  });
 });

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -19,7 +19,7 @@ describe("parse", () => {
     expect(result.summary).toEqual(expected.summary);
   });
 
-  it("should parse a level with a summary", () => {
+  it("should parse a level with no steps", () => {
     const md = `# Title
     
 Description.
@@ -44,6 +44,45 @@ levels:
           summary:
             "Level's summary: a short description of the level's content in one line.",
           content: "Some text",
+        },
+      ],
+    };
+    expect(result.levels).toEqual(expected.levels);
+  });
+
+  it("should parse a level with a step", () => {
+    const md = `# Title
+    
+Description.
+
+## L1 Put Level's title here
+
+> Level's summary: a short description of the level's content in one line.
+
+Some text
+`;
+
+    const yaml = `version: "0.1.0"
+levels:
+- id: L1
+  setup:
+    files: []
+    commits: []
+  solution:
+    files: []
+    commits: []
+`;
+    const result = parse(md, yaml);
+    const expected = {
+      levels: [
+        {
+          id: "L1",
+          title: "Put Level's title here",
+          summary:
+            "Level's summary: a short description of the level's content in one line.",
+          content: "Some text",
+          setup: { files: [], commits: [] },
+          solution: { files: [], commits: [] },
         },
       ],
     };


### PR DESCRIPTION
If a level summary `>` is not included, it uses the content to populate the level summary.

If the summary is over 80 characters it gets truncated.