### PR TITLE
Feature/markdown as master

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ The configuration file is created by matching the `level` and `step` ids between
 
 Tutorial description.
 
-## L1 This is a level with id = 1
+## 1. This is a level with id = 1
 
 This level has two steps...
 
-### L1S1 First step
+### 1.1 First step
 
 The first step with id L1S1. The Step id should start with the level id.
 
@@ -62,7 +62,7 @@ The first step with id L1S1. The Step id should start with the level id.
 - The second hint that will show
 - The third and final hint, as it is last in order
 
-### L1S2 The second step
+### 1.2 The second step
 
 The second step...
 ```
@@ -72,10 +72,10 @@ The second step...
 ```yaml
 ---
 levels:
-  - id: L1
+  - id: "1"
     config: {}
     steps:
-      - id: L1S1
+      - id: "1.1"
         setup:
           files:
             - package.json
@@ -86,7 +86,7 @@ levels:
             - package.json
           commands:
             - npm install
-      - id: L1S2
+      - id: "1.2"
         setup:
           files:
             - src/server.js
@@ -104,23 +104,19 @@ commit 8e0e3a42ae565050181fdb68298114df21467a74 (HEAD -> v2, origin/v2)
 Author: creator <author@email.com>
 Date:   Sun May 3 16:16:01 2020 -0700
 
-    L1S1Q setup step 1 for level 1
+    1.1 setup for level 1, step 1
 
 commit 9499611fc9b311040dcabaf2d98439fc0c356cc9
 Author: creator <author@email.com>
 Date:   Sun May 3 16:13:37 2020 -0700
 
-    L1S2A checkout solution for level 1, step 2
+    1.1S solution for level 1, step 1
 
 commit c5c62041282579b495d3589b2eb1fdda2bcd7155
 Author: creator <author@email.com>
 Date:   Sun May 3 16:11:42 2020 -0700
 
-    L1S2Q setup level 1, step 2
+    1.2 setup for level 1, step 2
 ```
 
-Note that the step `L1S2` has two commits, one with the suffix `Q` and another one with `A`. The suffixes mean `Question` and `Answer`, respectively, and refer to the unit tests and the commit that makes them pass.
-
-Steps defined as questions are **required** as they are meant to set the task to be executed by the student. The answer is optional and should be used when a commit must be loaded to verify the student's solution.
-
-If there are multiple commits for a level or step, they are captured in order.
+Note that the step `1.1` has two commits, one with the suffix `S`. The first commit refers to the required tests and setup, while the second optional commit contains the solution. If there are multiple commits for a level or step, they are captured in order.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@coderoad/cli",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coderoad/cli",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "A CLI to build the configuration file for Coderoad Tutorials",
   "keywords": [
     "coderoad",

--- a/src/build.ts
+++ b/src/build.ts
@@ -102,7 +102,7 @@ async function build(args: string[]) {
   try {
     const valid = validateSchema(skeletonSchema, skeleton);
     if (!valid) {
-      console.error("Tutorial validation failed. See above to see what to fix");
+      console.error("Skeleton validation failed. See above to see what to fix");
       return;
     }
   } catch (e) {

--- a/src/schema/meta.ts
+++ b/src/schema/meta.ts
@@ -95,5 +95,40 @@ export default {
       },
       additionalProperties: false,
     },
+    setup_action_without_commits: {
+      type: "object",
+      description:
+        "A collection of files/commands that run when a level/step or solution is loaded",
+      properties: {
+        files: {
+          $ref: "#/definitions/file_array",
+        },
+        commands: {
+          $ref: "#/definitions/command_array",
+        },
+        watchers: {
+          type: "array",
+          items: {
+            $ref: "#/definitions/file_path",
+            // uniqueItems: true,
+          },
+          description:
+            "An array file paths that, when updated, will trigger the test runner to run",
+        },
+        filter: {
+          type: "string",
+          description:
+            "A regex pattern that will be passed to the test runner to limit the number of tests running",
+          examples: ["^TestSuiteName"],
+        },
+        subtasks: {
+          type: "boolean",
+          description:
+            'A feature that shows subtasks: all active test names and the status of the tests (pass/fail). Use together with "filter"',
+          examples: [true],
+        },
+      },
+      additionalProperties: false,
+    },
   },
 };

--- a/src/schema/skeleton.ts
+++ b/src/schema/skeleton.ts
@@ -53,9 +53,9 @@ export default {
               examples: ["coderoad"],
             },
             setup: {
-              $ref: "#/definitions/setup_action",
+              $ref: "#/definitions/setup_action_without_commits",
               description:
-                "Setup commits or commands used for setting up the test runner on tutorial launch",
+                "Setup actions or commands used for setting up the test runner on tutorial launch",
             },
           },
           required: ["command", "args"],
@@ -135,9 +135,9 @@ export default {
             examples: ["L1", "L11"],
           },
           setup: {
-            $ref: "#/definitions/setup_action",
+            $ref: "#/definitions/setup_action_without_commits",
             description:
-              "An optional point for loading commits, running commands or opening files",
+              "An optional point for running actions, commands or opening files",
           },
           steps: {
             type: "array",
@@ -152,18 +152,18 @@ export default {
                 setup: {
                   allOf: [
                     {
-                      $ref: "#/definitions/setup_action",
+                      $ref: "#/definitions/setup_action_without_commits",
                       description:
-                        "A point for loading commits. It can also run commands and/or open files",
+                        "A point for running actions, commands and/or opening files",
                     },
                   ],
                 },
                 solution: {
                   allOf: [
                     {
-                      $ref: "#/definitions/setup_action",
+                      $ref: "#/definitions/setup_action_without_commits",
                       description:
-                        "The solution commits that can be loaded if the user gets stuck. It can also run commands and/or open files",
+                        "The solution can be loaded if the user gets stuck. It can run actions, commands and/or open files",
                     },
                     {
                       required: [],

--- a/src/schema/tutorial.ts
+++ b/src/schema/tutorial.ts
@@ -211,7 +211,7 @@ export default {
                   examples: ["Have you tried doing X?"],
                 },
               },
-              required: ["content", "setup", "solution"],
+              required: ["content", "setup"],
             },
           },
         },

--- a/src/utils/commits.ts
+++ b/src/utils/commits.ts
@@ -73,7 +73,7 @@ export async function getCommits({
           commits[position] = [commit.hash];
         } else {
           // add to the list
-          commits[position].push(commit.hash);
+          commits[position].unshift(commit.hash);
         }
         positions.unshift(position);
       } else {
@@ -84,7 +84,7 @@ export async function getCommits({
             commits.INIT = [commit.hash];
           } else {
             // add to the list
-            commits.INIT.push(commit.hash);
+            commits.INIT.unshift(commit.hash);
           }
           positions.unshift("INIT");
         }
@@ -100,6 +100,8 @@ export async function getCommits({
     // cleanup the tmp directory
     await rmdir(tmpDir, { recursive: true });
   }
+
+  console.log(commits);
 
   return commits;
 }

--- a/src/utils/commits.ts
+++ b/src/utils/commits.ts
@@ -62,7 +62,7 @@ export async function getCommits({
 
     for (const commit of logs.all) {
       const matches = commit.message.match(
-        /^(?<stepId>(?<levelId>L\d+)(S\d+))(?<stepType>[QA])?/
+        /^(?<stepId>(?<levelId>L?\d+)([S|\.]\d+))(?<stepType>[QA])?/
       );
 
       if (matches && matches.length) {

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -150,7 +150,7 @@ export function parse(params: ParseParams): any {
                 ...mdStep,
               };
 
-              const stepSetupKey = `${step.id}Q`;
+              const stepSetupKey = `${step.id}:T`;
               if (params.commits[stepSetupKey]) {
                 if (!step.setup) {
                   step.setup = {
@@ -160,7 +160,7 @@ export function parse(params: ParseParams): any {
                 step.setup.commits = params.commits[stepSetupKey];
               }
 
-              const stepSolutionKey = `${step.id}A`;
+              const stepSolutionKey = `${step.id}:S`;
               if (params.commits[stepSolutionKey]) {
                 if (!step.solution) {
                   step.solution = {

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -187,6 +187,14 @@ export function parse(params: ParseParams): any {
         level.setup.commits = params.commits[level.id];
       }
 
+      // @deprecated L1 system
+      if (params.commits[`L${level.id}`]) {
+        if (!level.setup) {
+          level.setup = {};
+        }
+        level.setup.commits = params.commits[`L${level.id}`];
+      }
+
       return level;
     }
   );

--- a/src/utils/validateCommits.ts
+++ b/src/utils/validateCommits.ts
@@ -14,17 +14,28 @@ export function validateCommitOrder(positions: string[]): boolean {
       return;
     } else {
       // @deprecate - remove L|Q
-      const levelMatch = position.match(/^L?([0-9]+)[Q|T]?$/);
+      const levelMatch = position.match(/^(?<level>[0-9]+)$/);
       // @deprecate - remove S|Q|A
-      const stepMatch = position.match(/^L?([0-9]+)[S|\.]([0-9]+)[Q|A|T|S]?$/);
+      const stepMatch = position.match(
+        /^(?<level>[0-9]+)\.(?<step>[0-9]+):[T|S]$/
+      );
       if (levelMatch) {
         // allows next level or step
-        const [_, levelString] = levelMatch;
+        const levelString = levelMatch?.groups?.level;
+        if (!levelString) {
+          console.warn(`No commit level match for ${position}`);
+          return;
+        }
         const level = Number(levelString);
         current = { level, step: 0 };
       } else if (stepMatch) {
         // allows next level or step
-        const [_, levelString, stepString] = stepMatch;
+        if (!stepMatch?.groups?.level || !stepMatch?.groups.step) {
+          console.warn(`No commit step match for ${position}`);
+          return;
+        }
+        const { level: levelString, step: stepString } = stepMatch.groups;
+
         const level = Number(levelString);
         const step = Number(stepString);
         current = { level, step };

--- a/src/utils/validateCommits.ts
+++ b/src/utils/validateCommits.ts
@@ -13,8 +13,8 @@ export function validateCommitOrder(positions: string[]): boolean {
       current = { level: 0, step: 0 };
       return;
     } else {
-      const levelMatch = position.match(/^L([0-9]+)Q?$/);
-      const stepMatch = position.match(/^L([0-9]+)S([0-9]+)[Q|A]?$/);
+      const levelMatch = position.match(/^L?([0-9]+)Q?$/);
+      const stepMatch = position.match(/^L?([0-9]+)[S|\.]([0-9]+)[Q|A]?$/);
       if (levelMatch) {
         // allows next level or step
         const [_, levelString] = levelMatch;

--- a/src/utils/validateCommits.ts
+++ b/src/utils/validateCommits.ts
@@ -13,8 +13,10 @@ export function validateCommitOrder(positions: string[]): boolean {
       current = { level: 0, step: 0 };
       return;
     } else {
-      const levelMatch = position.match(/^L?([0-9]+)Q?$/);
-      const stepMatch = position.match(/^L?([0-9]+)[S|\.]([0-9]+)[Q|A]?$/);
+      // @deprecate - remove L|Q
+      const levelMatch = position.match(/^L?([0-9]+)[Q|T]?$/);
+      // @deprecate - remove S|Q|A
+      const stepMatch = position.match(/^L?([0-9]+)[S|\.]([0-9]+)[Q|A|T|S]?$/);
       if (levelMatch) {
         // allows next level or step
         const [_, levelString] = levelMatch;

--- a/src/utils/validateCommits.ts
+++ b/src/utils/validateCommits.ts
@@ -3,21 +3,21 @@
 export function validateCommitOrder(positions: string[]): boolean {
   // loop over positions
   const errors: number[] = [];
-  let previous = { level: 0, step: 0 };
-  let current = { level: 0, step: 0 };
+  let previous = { level: 0, step: 0, type: "" };
+  let current = { level: 0, step: 0, type: "" };
   positions.forEach((position: string, index: number) => {
     if (position === "INIT") {
       if (previous.level !== 0 && previous.step !== 0) {
         errors.push(index);
       }
-      current = { level: 0, step: 0 };
+      current = { level: 0, step: 0, type: "" };
       return;
     } else {
       // @deprecate - remove L|Q
       const levelMatch = position.match(/^(?<level>[0-9]+)$/);
       // @deprecate - remove S|Q|A
       const stepMatch = position.match(
-        /^(?<level>[0-9]+)\.(?<step>[0-9]+):[T|S]$/
+        /^(?<level>[0-9]+)\.(?<step>[0-9]+):(?<stepType>[T|S])$/
       );
       if (levelMatch) {
         // allows next level or step
@@ -27,7 +27,7 @@ export function validateCommitOrder(positions: string[]): boolean {
           return;
         }
         const level = Number(levelString);
-        current = { level, step: 0 };
+        current = { level, step: 0, type: "" };
       } else if (stepMatch) {
         // allows next level or step
         if (!stepMatch?.groups?.level || !stepMatch?.groups.step) {
@@ -38,13 +38,26 @@ export function validateCommitOrder(positions: string[]): boolean {
 
         const level = Number(levelString);
         const step = Number(stepString);
-        current = { level, step };
+        const type = stepMatch?.groups.stepType;
+
+        const sameStep = previous.level === level && previous.step === step;
+
+        if (
+          // tests should come before the solution
+          (sameStep && type === "T" && previous.type === "S") ||
+          // step should have tests
+          (!sameStep && type === "S")
+        ) {
+          errors.push(index);
+        }
+        current = { level, step, type };
       } else {
         // error
         console.warn(`Invalid commit position: ${position}`);
         return;
       }
       if (
+        // levels or steps are out of order
         current.level < previous.level ||
         (current.level === previous.level && current.step < previous.step)
       ) {

--- a/src/utils/validateMarkdown.ts
+++ b/src/utils/validateMarkdown.ts
@@ -24,11 +24,11 @@ const validations: Validation[] = [
     },
   },
   {
-    message: "should have a level `##` with a format of `L[0-9]+`",
+    message: "should have a level `##` with a format of `[0-9]+.`",
     validate: (t) => {
       const headers = t.match(/^#{2}\s(.+)$/gm) || [];
       for (const header of headers) {
-        if (!header.match(/^#{2}\s(L\d+)\s(.+)$/)) {
+        if (!header.match(/^#{2}\s(\d+\.)\s(.+)$/)) {
           return false;
         }
       }
@@ -36,11 +36,11 @@ const validations: Validation[] = [
     },
   },
   {
-    message: "should have a step `###` with a format of `L[0-9]+S[0-9]+`",
+    message: "should have a step `###` with a format of `[0-9].[0-9]+`",
     validate: (t) => {
       const headers = t.match(/^#{3}\s(.+)$/gm) || [];
       for (const header of headers) {
-        if (!header.match(/^#{3}\s(L\d+)S\d+/)) {
+        if (!header.match(/^#{3}\s(\d+\.\d+)/)) {
           return false;
         }
       }
@@ -60,9 +60,9 @@ export function validateMarkdown(md: string): boolean {
   for (const v of validations) {
     if (!v.validate(text)) {
       valid = false;
-      if (process.env.NODE_ENV !== "test") {
-        console.warn(v.message);
-      }
+      // if (process.env.NODE_ENV !== "test") {
+      console.warn(v.message);
+      // }
     }
   }
 

--- a/tests/commitOrder.test.ts
+++ b/tests/commitOrder.test.ts
@@ -14,6 +14,8 @@ describe("commitOrder", () => {
         "1",
         "1",
         "1.1:T",
+        "1.1:T",
+        "1.1:S",
         "1.1:S",
         "1.2:T",
         "1.2:S",
@@ -42,6 +44,16 @@ describe("commitOrder", () => {
     });
     it("should return false if step is out of order", () => {
       const positions = ["INIT", "1", "1.1:T", "1.3:T", "1.2:T"];
+      const result = validateCommitOrder(positions);
+      expect(result).toBe(false);
+    });
+    it("should return false if solution is before step", () => {
+      const positions = ["INIT", "1", "1.1:S", "1.1:T", "1.2:T"];
+      const result = validateCommitOrder(positions);
+      expect(result).toBe(false);
+    });
+    it("should return false if solution but no test step", () => {
+      const positions = ["INIT", "1", "1.1:S", "1.2:T"];
       const result = validateCommitOrder(positions);
       expect(result).toBe(false);
     });

--- a/tests/commitOrder.test.ts
+++ b/tests/commitOrder.test.ts
@@ -3,7 +3,7 @@ import { validateCommitOrder } from "../src/utils/validateCommits";
 describe("commitOrder", () => {
   describe("#.# format", () => {
     it("should return true if order is valid", () => {
-      const positions = ["INIT", "1", "1.1", "1.2", "2", "2.1"];
+      const positions = ["INIT", "1", "1.1:T", "1.2:T", "2", "2.1:T"];
       const result = validateCommitOrder(positions);
       expect(result).toBe(true);
     });
@@ -13,81 +13,35 @@ describe("commitOrder", () => {
         "INIT",
         "1",
         "1",
-        "1.1",
-        "1.1",
-        "1.2",
-        "1.2",
+        "1.1:T",
+        "1.1:S",
+        "1.2:T",
+        "1.2:S",
         "2",
         "2",
-        "2.1",
-        "2.1",
+        "2.1:T",
+        "2.1:S",
       ];
       const result = validateCommitOrder(positions);
       expect(result).toBe(true);
     });
     it("should return false if INIT is out of order", () => {
-      const positions = ["INIT", "1", "1.1", "1.2", "INIT", "2", "2.1"];
+      const positions = ["INIT", "1", "1.1:T", "1.2:T", "INIT", "2", "2.1:T"];
       const result = validateCommitOrder(positions);
       expect(result).toBe(false);
     });
     it("should return false if level after step is out of order", () => {
-      const positions = ["INIT", "1", "1.1", "1.2", "2.1", "2"];
+      const positions = ["INIT", "1", "1.1:T", "1.2:T", "2.1:T", "2"];
       const result = validateCommitOrder(positions);
       expect(result).toBe(false);
     });
     it("should return false if level is out of order", () => {
-      const positions = ["INIT", "1", "L3", "2"];
+      const positions = ["INIT", "1", "3", "2"];
       const result = validateCommitOrder(positions);
       expect(result).toBe(false);
     });
     it("should return false if step is out of order", () => {
-      const positions = ["INIT", "1", "1.1", "1.3", "1.2"];
-      const result = validateCommitOrder(positions);
-      expect(result).toBe(false);
-    });
-  });
-  // @deprecated
-  describe("L#S# format", () => {
-    it("should return true if order is valid", () => {
-      const positions = ["INIT", "L1", "L1S1", "L1S2", "L2", "L2S1"];
-      const result = validateCommitOrder(positions);
-      expect(result).toBe(true);
-    });
-    it("should return true if valid with duplicates", () => {
-      const positions = [
-        "INIT",
-        "INIT",
-        "L1",
-        "L1",
-        "L1S1",
-        "L1S1",
-        "L1S2",
-        "L1S2",
-        "L2",
-        "L2",
-        "L2S1",
-        "L2S1",
-      ];
-      const result = validateCommitOrder(positions);
-      expect(result).toBe(true);
-    });
-    it("should return false if INIT is out of order", () => {
-      const positions = ["INIT", "L1", "L1S1", "L1S2", "INIT", "L2", "L2S1"];
-      const result = validateCommitOrder(positions);
-      expect(result).toBe(false);
-    });
-    it("should return false if level after step is out of order", () => {
-      const positions = ["INIT", "L1", "L1S1", "L1S2", "L2S1", "L2"];
-      const result = validateCommitOrder(positions);
-      expect(result).toBe(false);
-    });
-    it("should return false if level is out of order", () => {
-      const positions = ["INIT", "L1", "L3", "L2"];
-      const result = validateCommitOrder(positions);
-      expect(result).toBe(false);
-    });
-    it("should return false if step is out of order", () => {
-      const positions = ["INIT", "L1", "L1S1", "L1S3", "L1S2"];
+      const positions = ["INIT", "1", "1.1:T", "1.3:T", "1.2:T"];
       const result = validateCommitOrder(positions);
       expect(result).toBe(false);
     });

--- a/tests/commitOrder.test.ts
+++ b/tests/commitOrder.test.ts
@@ -2,7 +2,7 @@ import { validateCommitOrder } from "../src/utils/validateCommits";
 
 describe("commitOrder", () => {
   it("should return true if order is valid", () => {
-    const positions = ["INIT", "L1", "L1S1", "L1S2", "L2", "L2S1"];
+    const positions = ["INIT", "1", "1.1", "1.2", "2", "2.1"];
     const result = validateCommitOrder(positions);
     expect(result).toBe(true);
   });
@@ -10,37 +10,37 @@ describe("commitOrder", () => {
     const positions = [
       "INIT",
       "INIT",
-      "L1",
-      "L1",
-      "L1S1",
-      "L1S1",
-      "L1S2",
-      "L1S2",
-      "L2",
-      "L2",
-      "L2S1",
-      "L2S1",
+      "1",
+      "1",
+      "1.1",
+      "1.1",
+      "1.2",
+      "1.2",
+      "2",
+      "2",
+      "2.1",
+      "2.1",
     ];
     const result = validateCommitOrder(positions);
     expect(result).toBe(true);
   });
   it("should return false if INIT is out of order", () => {
-    const positions = ["INIT", "L1", "L1S1", "L1S2", "INIT", "L2", "L2S1"];
+    const positions = ["INIT", "1", "1.1", "1.2", "INIT", "2", "2.1"];
     const result = validateCommitOrder(positions);
     expect(result).toBe(false);
   });
   it("should return false if level after step is out of order", () => {
-    const positions = ["INIT", "L1", "L1S1", "L1S2", "L2S1", "L2"];
+    const positions = ["INIT", "1", "1.1", "1.2", "2.1", "2"];
     const result = validateCommitOrder(positions);
     expect(result).toBe(false);
   });
   it("should return false if level is out of order", () => {
-    const positions = ["INIT", "L1", "L3", "L2"];
+    const positions = ["INIT", "1", "L3", "2"];
     const result = validateCommitOrder(positions);
     expect(result).toBe(false);
   });
   it("should return false if step is out of order", () => {
-    const positions = ["INIT", "L1", "L1S1", "L1S3", "L1S2"];
+    const positions = ["INIT", "1", "1.1", "1.3", "1.2"];
     const result = validateCommitOrder(positions);
     expect(result).toBe(false);
   });

--- a/tests/commitOrder.test.ts
+++ b/tests/commitOrder.test.ts
@@ -1,47 +1,95 @@
 import { validateCommitOrder } from "../src/utils/validateCommits";
 
 describe("commitOrder", () => {
-  it("should return true if order is valid", () => {
-    const positions = ["INIT", "1", "1.1", "1.2", "2", "2.1"];
-    const result = validateCommitOrder(positions);
-    expect(result).toBe(true);
+  describe("#.# format", () => {
+    it("should return true if order is valid", () => {
+      const positions = ["INIT", "1", "1.1", "1.2", "2", "2.1"];
+      const result = validateCommitOrder(positions);
+      expect(result).toBe(true);
+    });
+    it("should return true if valid with duplicates", () => {
+      const positions = [
+        "INIT",
+        "INIT",
+        "1",
+        "1",
+        "1.1",
+        "1.1",
+        "1.2",
+        "1.2",
+        "2",
+        "2",
+        "2.1",
+        "2.1",
+      ];
+      const result = validateCommitOrder(positions);
+      expect(result).toBe(true);
+    });
+    it("should return false if INIT is out of order", () => {
+      const positions = ["INIT", "1", "1.1", "1.2", "INIT", "2", "2.1"];
+      const result = validateCommitOrder(positions);
+      expect(result).toBe(false);
+    });
+    it("should return false if level after step is out of order", () => {
+      const positions = ["INIT", "1", "1.1", "1.2", "2.1", "2"];
+      const result = validateCommitOrder(positions);
+      expect(result).toBe(false);
+    });
+    it("should return false if level is out of order", () => {
+      const positions = ["INIT", "1", "L3", "2"];
+      const result = validateCommitOrder(positions);
+      expect(result).toBe(false);
+    });
+    it("should return false if step is out of order", () => {
+      const positions = ["INIT", "1", "1.1", "1.3", "1.2"];
+      const result = validateCommitOrder(positions);
+      expect(result).toBe(false);
+    });
   });
-  it("should return true if valid with duplicates", () => {
-    const positions = [
-      "INIT",
-      "INIT",
-      "1",
-      "1",
-      "1.1",
-      "1.1",
-      "1.2",
-      "1.2",
-      "2",
-      "2",
-      "2.1",
-      "2.1",
-    ];
-    const result = validateCommitOrder(positions);
-    expect(result).toBe(true);
-  });
-  it("should return false if INIT is out of order", () => {
-    const positions = ["INIT", "1", "1.1", "1.2", "INIT", "2", "2.1"];
-    const result = validateCommitOrder(positions);
-    expect(result).toBe(false);
-  });
-  it("should return false if level after step is out of order", () => {
-    const positions = ["INIT", "1", "1.1", "1.2", "2.1", "2"];
-    const result = validateCommitOrder(positions);
-    expect(result).toBe(false);
-  });
-  it("should return false if level is out of order", () => {
-    const positions = ["INIT", "1", "L3", "2"];
-    const result = validateCommitOrder(positions);
-    expect(result).toBe(false);
-  });
-  it("should return false if step is out of order", () => {
-    const positions = ["INIT", "1", "1.1", "1.3", "1.2"];
-    const result = validateCommitOrder(positions);
-    expect(result).toBe(false);
+  // @deprecated
+  describe("L#S# format", () => {
+    it("should return true if order is valid", () => {
+      const positions = ["INIT", "L1", "L1S1", "L1S2", "L2", "L2S1"];
+      const result = validateCommitOrder(positions);
+      expect(result).toBe(true);
+    });
+    it("should return true if valid with duplicates", () => {
+      const positions = [
+        "INIT",
+        "INIT",
+        "L1",
+        "L1",
+        "L1S1",
+        "L1S1",
+        "L1S2",
+        "L1S2",
+        "L2",
+        "L2",
+        "L2S1",
+        "L2S1",
+      ];
+      const result = validateCommitOrder(positions);
+      expect(result).toBe(true);
+    });
+    it("should return false if INIT is out of order", () => {
+      const positions = ["INIT", "L1", "L1S1", "L1S2", "INIT", "L2", "L2S1"];
+      const result = validateCommitOrder(positions);
+      expect(result).toBe(false);
+    });
+    it("should return false if level after step is out of order", () => {
+      const positions = ["INIT", "L1", "L1S1", "L1S2", "L2S1", "L2"];
+      const result = validateCommitOrder(positions);
+      expect(result).toBe(false);
+    });
+    it("should return false if level is out of order", () => {
+      const positions = ["INIT", "L1", "L3", "L2"];
+      const result = validateCommitOrder(positions);
+      expect(result).toBe(false);
+    });
+    it("should return false if step is out of order", () => {
+      const positions = ["INIT", "L1", "L1S1", "L1S3", "L1S2"];
+      const result = validateCommitOrder(positions);
+      expect(result).toBe(false);
+    });
   });
 });

--- a/tests/commitParse.test.ts
+++ b/tests/commitParse.test.ts
@@ -1,0 +1,151 @@
+import { parseCommits } from "../src/utils/commits";
+
+describe("commitParse", () => {
+  it("should parse out #. commits", () => {
+    const logs = {
+      all: [
+        {
+          message: "INIT",
+          hash: "1",
+        },
+        {
+          message: "1. First Level",
+          hash: "2",
+        },
+        {
+          message: "1.1 First Step",
+          hash: "3",
+        },
+      ],
+      total: 2,
+      latest: {},
+    };
+    const commits = parseCommits(logs);
+    expect(commits).toEqual({
+      INIT: ["1"],
+      "1": ["2"],
+      "1.1:T": ["3"],
+    });
+  });
+  // @deprecated - remove L#
+  it("should parse out L# commits", () => {
+    const logs = {
+      all: [
+        {
+          message: "INIT",
+          hash: "1",
+        },
+        {
+          message: "L1 First Level",
+          hash: "2",
+        },
+        {
+          message: "L1S1 First Step",
+          hash: "3",
+        },
+      ],
+      total: 2,
+      latest: {},
+    };
+    const commits = parseCommits(logs);
+    expect(commits).toEqual({
+      INIT: ["1"],
+      "1": ["2"],
+      "1.1:T": ["3"],
+    });
+  });
+  // @deprecated - remove with QA
+  it("should parse out #.Q|A commits", () => {
+    const logs = {
+      all: [
+        {
+          message: "INIT",
+          hash: "1",
+        },
+        {
+          message: "1. First Level",
+          hash: "2",
+        },
+        {
+          message: "1.1Q First Step",
+          hash: "3",
+        },
+        {
+          message: "1.1A First Step Solution",
+          hash: "4",
+        },
+      ],
+      total: 2,
+      latest: {},
+    };
+    const commits = parseCommits(logs);
+    expect(commits).toEqual({
+      INIT: ["1"],
+      "1": ["2"],
+      "1.1:T": ["3"],
+      "1.1:S": ["4"],
+    });
+  });
+  it("should parse out #.T|S commits", () => {
+    const logs = {
+      all: [
+        {
+          message: "INIT",
+          hash: "1",
+        },
+        {
+          message: "1. First Level",
+          hash: "2",
+        },
+        {
+          message: "1.1T First Step",
+          hash: "3",
+        },
+        {
+          message: "1.1S First Step Solution",
+          hash: "4",
+        },
+      ],
+      total: 2,
+      latest: {},
+    };
+    const commits = parseCommits(logs);
+    expect(commits).toEqual({
+      INIT: ["1"],
+      "1": ["2"],
+      "1.1:T": ["3"],
+      "1.1:S": ["4"],
+    });
+  });
+  it("should parse out #._|S commits", () => {
+    const logs = {
+      all: [
+        {
+          message: "INIT",
+          hash: "1",
+        },
+        {
+          message: "1. First Level",
+          hash: "2",
+        },
+        {
+          message: "1.1 First Step",
+          hash: "3",
+        },
+        {
+          message: "1.1S First Step Solution",
+          hash: "4",
+        },
+      ],
+      total: 2,
+      latest: {},
+    };
+    const commits = parseCommits(logs);
+    expect(commits).toEqual({
+      INIT: ["1"],
+      "1": ["2"],
+      "1.1:T": ["3"],
+      "1.1:S": ["4"],
+    });
+  });
+});

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -5,7 +5,7 @@ describe("validate markdown", () => {
     const md = `
 Description.
 
-## L1 Put Level's title here
+## Put Level's title here
 
 > Level's summary: a short description of the level's content in one line.
 
@@ -19,7 +19,7 @@ Description.
 
 # Another Title
 
-## L1 Put Level's title here
+## Put Level's title here
 
 > Level's summary: a short description of the level's content in one line.
 
@@ -29,7 +29,7 @@ Some text that describes the level`;
 Description.
 
 
-## L1 Put Level's title here
+## Put Level's title here
 
 > Level's summary: a short description of the level's content in one line.
 
@@ -45,7 +45,7 @@ Some text that describes the level
   it("should return false if missing a summary description", () => {
     const md = `# A Title
 
-## L1 Put Level's title here
+## Put Level's title here
 
 > Level's summary: a short description of the level's content in one line.
 
@@ -90,13 +90,13 @@ First step
 
 Description.
 
-## L1 Put Level's title here
+## Put Level's title here
 
 > Level's summary: a short description of the level's content in one line.
 
 Some text that describes the level
 
-### L1S1
+### Step 1
 
 First Step`;
     expect(validateMarkdown(md)).toBe(true);
@@ -114,7 +114,7 @@ Should not be a problem
 \`\`\`
 
 
-## L1 Put Level's title here
+## Put Level's title here
 
 > Level's summary: a short description of the level's content in one line.
 
@@ -126,7 +126,7 @@ Some text that describes the level
 Should not be an issue
 \`\`\`
 
-### L1S1
+### Step 1
 
 First Step`;
     expect(validateMarkdown(md)).toBe(true);

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -5,7 +5,7 @@ describe("validate markdown", () => {
     const md = `
 Description.
 
-## Put Level's title here
+## 1. Put Level's title here
 
 > Level's summary: a short description of the level's content in one line.
 
@@ -19,7 +19,7 @@ Description.
 
 # Another Title
 
-## Put Level's title here
+## 1. Put Level's title here
 
 > Level's summary: a short description of the level's content in one line.
 
@@ -29,7 +29,7 @@ Some text that describes the level`;
 Description.
 
 
-## Put Level's title here
+## 1. Put Level's title here
 
 > Level's summary: a short description of the level's content in one line.
 
@@ -45,7 +45,7 @@ Some text that describes the level
   it("should return false if missing a summary description", () => {
     const md = `# A Title
 
-## Put Level's title here
+## 1. Put Level's title here
 
 > Level's summary: a short description of the level's content in one line.
 
@@ -79,10 +79,11 @@ A description
 
 Some text that describes the level
 
-### A Step
+### Missing step id
 
 First step
 `;
+    expect(validateMarkdown(md)).toBe(false);
   });
 
   it("should return true for valid markdown", () => {
@@ -90,13 +91,13 @@ First step
 
 Description.
 
-## Put Level's title here
+## 1. Put Level's title here
 
 > Level's summary: a short description of the level's content in one line.
 
 Some text that describes the level
 
-### Step 1
+### 1.1
 
 First Step`;
     expect(validateMarkdown(md)).toBe(true);
@@ -114,19 +115,19 @@ Should not be a problem
 \`\`\`
 
 
-## Put Level's title here
+## 1. Put Level's title here
 
 > Level's summary: a short description of the level's content in one line.
 
 Some text that describes the level
 
 \`\`\`
-## Another Level in markdown
+## 2. Another Level in markdown
 
 Should not be an issue
 \`\`\`
 
-### Step 1
+### 1.1
 
 First Step`;
     expect(validateMarkdown(md)).toBe(true);

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -32,7 +32,7 @@ Short description to be shown as a tutorial's subtitle.
     
 Description.
 
-## L1 Put Level's title here
+## Put Level's title here
 
 > Level's summary: a short description of the level's content in one line.
 
@@ -51,7 +51,7 @@ Some text
       const expected = {
         levels: [
           {
-            id: "L1",
+            id: "1",
             title: "Put Level's title here",
             summary:
               "Level's summary: a short description of the level's content in one line.",
@@ -68,7 +68,7 @@ Some text
     
 Description.
 
-## L1 Put Level's title here
+## Put Level's title here
 
 > Level's summary: a short description of the level's content in one line.
 
@@ -78,7 +78,7 @@ Some text
       const skeleton = {
         levels: [
           {
-            id: "L1",
+            id: "1",
             setup: { files: [], commits: [] },
             solution: { files: [], commits: [] },
             steps: [],
@@ -93,7 +93,7 @@ Some text
       const expected = {
         levels: [
           {
-            id: "L1",
+            id: "1",
             title: "Put Level's title here",
             summary:
               "Level's summary: a short description of the level's content in one line.",
@@ -112,12 +112,12 @@ Some text
     
 Description.
 
-## L1 Put Level's title here
+## Put Level's title here
 
 Some text that becomes the summary
 `;
 
-      const skeleton = { levels: [{ id: "L1" }] };
+      const skeleton = { levels: [{ id: "1" }] };
       const result = parse({
         text: md,
         skeleton,
@@ -126,7 +126,7 @@ Some text that becomes the summary
       const expected = {
         levels: [
           {
-            id: "L1",
+            id: "1",
             title: "Put Level's title here",
             summary: "Some text that becomes the summary",
             content: "Some text that becomes the summary",
@@ -142,12 +142,12 @@ Some text that becomes the summary
     
 Description.
 
-## L1 Put Level's title here
+## Put Level's title here
 
 Some text that becomes the summary and goes beyond the maximum length of 80 so that it gets truncated at the end
 `;
 
-      const skeleton = { levels: [{ id: "L1" }] };
+      const skeleton = { levels: [{ id: "1" }] };
       const result = parse({
         text: md,
         skeleton,
@@ -156,7 +156,7 @@ Some text that becomes the summary and goes beyond the maximum length of 80 so t
       const expected = {
         levels: [
           {
-            id: "L1",
+            id: "1",
             title: "Put Level's title here",
             summary: "Some text that becomes the summary",
             content: "Some text that becomes the summary",
@@ -171,14 +171,14 @@ Some text that becomes the summary and goes beyond the maximum length of 80 so t
     
 Description.
 
-## L1 Put Level's title here
+## 1 Put Level's title here
 
 Some text.
 
 But not including this line.
 `;
 
-      const skeleton = { levels: [{ id: "L1" }] };
+      const skeleton = { levels: [{ id: "1" }] };
       const result = parse({
         text: md,
         skeleton,
@@ -187,7 +187,7 @@ But not including this line.
       const expected = {
         levels: [
           {
-            id: "L1",
+            id: "1",
             title: "Put Level's title here",
             summary: "Some text.",
             content: "Some text.\n\nBut not including this line.",
@@ -203,7 +203,7 @@ But not including this line.
 
 Description.
 
-## L1 Put Level's title here
+## Put Level's title here
 
 >
 
@@ -212,7 +212,7 @@ Some text.
 But not including this line.
 `;
 
-      const skeleton = { levels: [{ id: "L1" }] };
+      const skeleton = { levels: [{ id: "1" }] };
       const result = parse({
         text: md,
         skeleton,
@@ -221,7 +221,7 @@ But not including this line.
       const expected = {
         levels: [
           {
-            id: "L1",
+            id: "1",
             title: "Put Level's title here",
             summary: "Some text.",
             content: "Some text.\n\nBut not including this line.",
@@ -239,7 +239,7 @@ Description.
 
 Second description line
 
-## L1 Titles
+## Titles
 
 First line
 
@@ -248,7 +248,7 @@ Second line
 Third line
 `;
 
-      const skeleton = { levels: [{ id: "L1" }] };
+      const skeleton = { levels: [{ id: "1" }] };
       const result = parse({
         text: md,
         skeleton,
@@ -260,7 +260,7 @@ Third line
         },
         levels: [
           {
-            id: "L1",
+            id: "1",
             summary: "Some text that becomes the summary",
             content: "First line\n\nSecond line\n\nThird line",
           },
@@ -275,21 +275,21 @@ Third line
     
 Description.
 
-## L1 Title
+## Title
 
 First line
 
-### L1S1 Step
+### 1.1
 
 The first step
 `;
       const skeleton = {
         levels: [
           {
-            id: "L1",
+            id: "1",
             steps: [
               {
-                id: "L1S1",
+                id: "1.1",
               },
             ],
           },
@@ -308,12 +308,12 @@ The first step
         },
         levels: [
           {
-            id: "L1",
+            id: "1",
             summary: "First line",
             content: "First line",
             steps: [
               {
-                id: "L1S1",
+                id: "1.1",
                 content: "The first step",
                 setup: {
                   commits: ["abcdefg1"],
@@ -331,21 +331,21 @@ The first step
     
 Description.
 
-## L1 Title
+## Title
 
 First line
 
-### L1S1 Step
+### 1.1 Step
 
 The first step
 `;
       const skeleton = {
         levels: [
           {
-            id: "L1",
+            id: "1",
             steps: [
               {
-                id: "L1S1",
+                id: "1.1",
               },
             ],
           },
@@ -364,12 +364,12 @@ The first step
         },
         levels: [
           {
-            id: "L1",
+            id: "1",
             summary: "First line",
             content: "First line",
             steps: [
               {
-                id: "L1S1",
+                id: "1.1",
                 content: "The first step",
                 setup: {
                   commits: ["abcdefg1", "123456789"],
@@ -387,18 +387,18 @@ The first step
     
 Description.
 
-## L1 Title
+## Title
 
 First line
 
-### L1S1
+### 1.1
 
 The first step
 `;
       const skeleton = {
         levels: [
           {
-            id: "L1",
+            id: "1",
           },
         ],
       };
@@ -415,7 +415,7 @@ The first step
         },
         levels: [
           {
-            id: "L1",
+            id: "1",
             summary: "First line",
             content: "First line",
             setup: {
@@ -432,11 +432,11 @@ The first step
     
 Description.
 
-## L1 Title
+## 1. Title
 
 First line
 
-### L1S1
+### 1.1
 
 The first step
 
@@ -451,10 +451,10 @@ Another line
       const skeleton = {
         levels: [
           {
-            id: "L1",
+            id: "1",
             steps: [
               {
-                id: "L1S1",
+                id: "1.1",
               },
             ],
           },
@@ -469,7 +469,7 @@ Another line
         },
       });
       const expected = {
-        id: "L1S1",
+        id: "1.1",
         setup: {
           commits: ["12345678"],
         },
@@ -484,21 +484,21 @@ Another line
     
 Description.
 
-## L1 Title
+## 1. Title
 
 First line
 
-### L1S1 Step
+### 1.1 Step
 
 The first step
 `;
       const skeleton = {
         levels: [
           {
-            id: "L1",
+            id: "1",
             steps: [
               {
-                id: "L1S1",
+                id: "1.1",
                 setup: {
                   commands: ["npm install"],
                   files: ["someFile.js"],
@@ -529,12 +529,12 @@ The first step
         },
         levels: [
           {
-            id: "L1",
+            id: "1",
             summary: "First line",
             content: "First line",
             steps: [
               {
-                id: "L1S1",
+                id: "1.1",
                 content: "The first step",
                 setup: {
                   commits: ["abcdefg1", "123456789"],
@@ -562,33 +562,33 @@ The first step
     
 Description.
 
-## L1 Title 1
+## 1. Title 1
 
 First level content.
 
-### L1S1
+### 1.1
 
 The first step
 
-### L1S2
+### 1.2
 
 The second step
 
-## L2 Title 2
+## 2. Title 2
 
 Second level content.
 
-### L2S1
+### 2.1
 
 The third step
 `;
       const skeleton = {
         levels: [
           {
-            id: "L1",
+            id: "1",
             steps: [
               {
-                id: "L1S1",
+                id: "1.1",
                 setup: {
                   commands: ["npm install"],
                   files: ["someFile.js"],
@@ -602,7 +602,7 @@ The third step
                 },
               },
               {
-                id: "L1S2",
+                id: "1.2",
                 setup: {
                   commands: ["npm install"],
                   files: ["someFile.js"],
@@ -618,12 +618,12 @@ The third step
             ],
           },
           {
-            id: "L2",
+            id: "2",
             summary: "Second level content.",
             content: "First level content.",
             steps: [
               {
-                id: "L2S1",
+                id: "2.1",
                 setup: {
                   commands: ["npm install"],
                   files: ["someFile.js"],
@@ -658,13 +658,13 @@ The third step
         },
         levels: [
           {
-            id: "L1",
+            id: "1",
             title: "Title 1",
             summary: "First level content.",
             content: "First level content.",
             steps: [
               {
-                id: "L1S1",
+                id: "L11.1S1",
                 content: "The first step",
                 setup: {
                   commits: ["abcdef1", "123456789"],
@@ -681,7 +681,7 @@ The third step
                 },
               },
               {
-                id: "L1S2",
+                id: "1.2",
                 content: "The second step",
                 setup: {
                   commits: ["2abcdef"],
@@ -700,13 +700,13 @@ The third step
             ],
           },
           {
-            id: "L2",
+            id: "2",
             title: "Title 2",
             summary: "Second level content.",
             content: "Second level content.",
             steps: [
               {
-                id: "L2S1",
+                id: "2.1",
                 content: "The third step",
                 setup: {
                   commits: ["4abcdef"],
@@ -734,11 +734,11 @@ The third step
     
 Description.
 
-## L1 Title 1
+## 1. Title 1
 
 First level content.
 
-### L1S1
+### 1.1
 
 The first step
 
@@ -746,10 +746,10 @@ The first step
       const skeleton = {
         levels: [
           {
-            id: "L1",
+            id: "1",
             steps: [
               {
-                id: "L1S1",
+                id: "1.1",
               },
             ],
           },
@@ -768,13 +768,13 @@ The first step
         },
         levels: [
           {
-            id: "L1",
+            id: "1",
             title: "Title 1",
             summary: "First level content.",
             content: "First level content.",
             steps: [
               {
-                id: "L1S1",
+                id: "1.1",
                 content: "The first step",
                 setup: {
                   commits: ["abcdef1", "123456789"],
@@ -941,11 +941,11 @@ Description.
     
 Description.
 
-## L1 Title 1
+## 1. Title 1
 
 First level content.
 
-### L1S1
+### 1.1
 
 The first step
 
@@ -958,10 +958,10 @@ The first step
       const skeleton = {
         levels: [
           {
-            id: "L1",
+            id: "1",
             steps: [
               {
-                id: "L1S1",
+                id: "1.1",
               },
             ],
           },
@@ -980,13 +980,13 @@ The first step
         },
         levels: [
           {
-            id: "L1",
+            id: "1",
             title: "Title 1",
             summary: "First level content.",
             content: "First level content.",
             steps: [
               {
-                id: "L1S1",
+                id: "1.1",
                 content: "The first step",
                 setup: {
                   commits: ["abcdef1", "123456789"],
@@ -1005,11 +1005,11 @@ The first step
     
 Description.
 
-## L1 Title 1
+## 1. Title 1
 
 First level content.
 
-### L1S1
+### 1.1
 
 The first step
 
@@ -1027,10 +1027,10 @@ And spans multiple lines.
       const skeleton = {
         levels: [
           {
-            id: "L1",
+            id: "1",
             steps: [
               {
-                id: "L1S1",
+                id: "1.1",
               },
             ],
           },
@@ -1049,13 +1049,13 @@ And spans multiple lines.
         },
         levels: [
           {
-            id: "L1",
+            id: "1",
             title: "Title 1",
             summary: "First level content.",
             content: "First level content.",
             steps: [
               {
-                id: "L1S1",
+                id: "1.1",
                 content: "The first step",
                 setup: {
                   commits: ["abcdef1", "123456789"],
@@ -1077,11 +1077,11 @@ And spans multiple lines.
     
 Description.
 
-## L1 Title 1
+## 1. Title 1
 
 First level content.
 
-### L1S1
+### 1.1
 
 The first step
 
@@ -1096,20 +1096,20 @@ var a = 1;
 
 And spans multiple lines.
 
-### L1S2
+### 1.2
 
 The second uninterrupted step
 `;
       const skeleton = {
         levels: [
           {
-            id: "L1",
+            id: "1",
             steps: [
               {
-                id: "L1S1",
+                id: "1.1",
               },
               {
-                id: "L1S2",
+                id: "1.2",
               },
             ],
           },
@@ -1130,13 +1130,13 @@ The second uninterrupted step
         },
         levels: [
           {
-            id: "L1",
+            id: "1",
             title: "Title 1",
             summary: "First level content.",
             content: "First level content.",
             steps: [
               {
-                id: "L1S1",
+                id: "1.1",
                 content: "The first step",
                 setup: {
                   commits: ["abcdef1"],
@@ -1150,7 +1150,7 @@ The second uninterrupted step
                 ],
               },
               {
-                id: "L1S2",
+                id: "1.2",
                 content: "The second uninterrupted step",
                 setup: {
                   commits: ["fedcba1"],

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -40,7 +40,7 @@ Some text
 `;
 
       const skeleton = {
-        levels: [{ id: "L1" }],
+        levels: [{ id: "1" }],
       };
 
       const result = parse({
@@ -299,7 +299,7 @@ The first step
         text: md,
         skeleton,
         commits: {
-          L1S1Q: ["abcdefg1"],
+          "1.1Q": ["abcdefg1"],
         },
       });
       const expected = {
@@ -355,7 +355,7 @@ The first step
         text: md,
         skeleton,
         commits: {
-          L1S1Q: ["abcdefg1", "123456789"],
+          "1.1Q": ["abcdefg1", "123456789"],
         },
       });
       const expected = {
@@ -406,7 +406,7 @@ The first step
         text: md,
         skeleton,
         commits: {
-          L1: ["abcdefg1"],
+          "1": ["abcdefg1"],
         },
       });
       const expected = {
@@ -464,8 +464,8 @@ Another line
         text: md,
         skeleton,
         commits: {
-          L1: ["abcdefg1"],
-          L1S1Q: ["12345678"],
+          "1": ["abcdefg1"],
+          "1.1Q": ["12345678"],
         },
       });
       const expected = {
@@ -519,8 +519,8 @@ The first step
         text: md,
         skeleton,
         commits: {
-          L1S1Q: ["abcdefg1", "123456789"],
-          L1S1A: ["1gfedcba", "987654321"],
+          "1.1Q": ["abcdefg1", "123456789"],
+          "1.1A": ["1gfedcba", "987654321"],
         },
       });
       const expected = {
@@ -644,12 +644,12 @@ The third step
         text: md,
         skeleton,
         commits: {
-          L1S1Q: ["abcdef1", "123456789"],
-          L1S1A: ["1fedcba", "987654321"],
-          L1S2Q: ["2abcdef"],
-          L1S2A: ["3abcdef"],
-          L2S1Q: ["4abcdef"],
-          L2S1A: ["5abcdef"],
+          "1.1Q": ["abcdef1", "123456789"],
+          "1.1A": ["1fedcba", "987654321"],
+          "1.2Q": ["2abcdef"],
+          "1.2A": ["3abcdef"],
+          "2.1Q": ["4abcdef"],
+          "2.1A": ["5abcdef"],
         },
       });
       const expected = {
@@ -664,7 +664,7 @@ The third step
             content: "First level content.",
             steps: [
               {
-                id: "L11.1S1",
+                id: "1.1",
                 content: "The first step",
                 setup: {
                   commits: ["abcdef1", "123456789"],
@@ -759,7 +759,7 @@ The first step
         text: md,
         skeleton,
         commits: {
-          L1S1Q: ["abcdef1", "123456789"],
+          "1.1Q": ["abcdef1", "123456789"],
         },
       });
       const expected = {
@@ -935,7 +935,7 @@ Description.
     });
   });
 
-  xdescribe("hints", () => {
+  describe("hints", () => {
     it("should parse hints for a step", () => {
       const md = `# Title
     
@@ -971,7 +971,7 @@ The first step
         text: md,
         skeleton,
         commits: {
-          L1S1Q: ["abcdef1", "123456789"],
+          "1.1Q": ["abcdef1", "123456789"],
         },
       });
       const expected = {
@@ -1040,7 +1040,7 @@ And spans multiple lines.
         text: md,
         skeleton,
         commits: {
-          L1S1Q: ["abcdef1", "123456789"],
+          "1.1Q": ["abcdef1", "123456789"],
         },
       });
       const expected = {
@@ -1119,9 +1119,9 @@ The second uninterrupted step
         text: md,
         skeleton,
         commits: {
-          L1S1Q: ["abcdef1"],
-          L1S1A: ["123456789"],
-          L1S2Q: ["fedcba1"],
+          "1.1Q": ["abcdef1"],
+          "1.1A": ["123456789"],
+          "1.2Q": ["fedcba1"],
         },
       });
       const expected = {

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -32,7 +32,7 @@ Short description to be shown as a tutorial's subtitle.
     
 Description.
 
-## Put Level's title here
+## 1. Put Level's title here
 
 > Level's summary: a short description of the level's content in one line.
 
@@ -68,7 +68,7 @@ Some text
     
 Description.
 
-## Put Level's title here
+## 1. Put Level's title here
 
 > Level's summary: a short description of the level's content in one line.
 
@@ -112,7 +112,7 @@ Some text
     
 Description.
 
-## Put Level's title here
+## 1. Put Level's title here
 
 Some text that becomes the summary
 `;
@@ -142,7 +142,7 @@ Some text that becomes the summary
     
 Description.
 
-## Put Level's title here
+## 1. Put Level's title here
 
 Some text that becomes the summary and goes beyond the maximum length of 80 so that it gets truncated at the end
 `;
@@ -171,7 +171,7 @@ Some text that becomes the summary and goes beyond the maximum length of 80 so t
     
 Description.
 
-## 1 Put Level's title here
+## 1. Put Level's title here
 
 Some text.
 
@@ -203,7 +203,7 @@ But not including this line.
 
 Description.
 
-## Put Level's title here
+## 1. Put Level's title here
 
 >
 
@@ -239,7 +239,7 @@ Description.
 
 Second description line
 
-## Titles
+## 1. Titles
 
 First line
 
@@ -275,7 +275,7 @@ Third line
     
 Description.
 
-## Title
+## 1. Title
 
 First line
 
@@ -331,7 +331,7 @@ The first step
     
 Description.
 
-## Title
+## 1. Title
 
 First line
 
@@ -387,7 +387,7 @@ The first step
     
 Description.
 
-## Title
+## 1. Title
 
 First line
 
@@ -935,7 +935,7 @@ Description.
     });
   });
 
-  describe("hints", () => {
+  xdescribe("hints", () => {
     it("should parse hints for a step", () => {
       const md = `# Title
     

--- a/tests/skeleton.test.ts
+++ b/tests/skeleton.test.ts
@@ -186,7 +186,7 @@ describe("validate skeleton", () => {
     const valid = validateSkeleton(json);
     expect(valid).toBe(false);
   });
-  it("should fial if level is missing id", () => {
+  it("should fail if level is missing id", () => {
     const level1 = { ...validJson.levels[0], id: undefined };
     const json = {
       ...validJson,

--- a/tests/skeleton.test.ts
+++ b/tests/skeleton.test.ts
@@ -30,7 +30,7 @@ const validJson = {
     {
       steps: [
         {
-          id: "L1S1",
+          id: "1.1",
           setup: {
             files: ["package.json"],
           },
@@ -39,7 +39,7 @@ const validJson = {
           },
         },
         {
-          id: "L1S2",
+          id: "1.2",
           setup: {
             commands: ["npm install"],
           },
@@ -48,7 +48,7 @@ const validJson = {
           },
         },
         {
-          id: "L1S3",
+          id: "1.3",
           setup: {
             files: ["package.json"],
             watchers: ["package.json", "node_modules/some-package"],
@@ -58,7 +58,7 @@ const validJson = {
           },
         },
         {
-          id: "L1S4",
+          id: "1.4",
           setup: {
             commands: [],
             filter: "^Example 2",
@@ -66,7 +66,7 @@ const validJson = {
           },
         },
       ],
-      id: "L1",
+      id: "1",
     },
   ],
 };

--- a/tests/tutorial.test.ts
+++ b/tests/tutorial.test.ts
@@ -39,7 +39,7 @@ describe("validate tutorial", () => {
       },
       levels: [
         {
-          id: "L1",
+          id: "1",
           title: "Level 1",
           summary: "The first level",
           content: "The first level",

--- a/typings/tutorial.d.ts
+++ b/typings/tutorial.d.ts
@@ -25,8 +25,8 @@ export type Level = {
 export type Step = {
   id: string;
   content: string;
-  setup: StepActions;
-  solution: Maybe<StepActions>;
+  setup?: StepActions;
+  solution?: Maybe<StepActions>;
   subtasks?: { [testName: string]: boolean };
   hints?: string[];
 };

--- a/typings/tutorial.d.ts
+++ b/typings/tutorial.d.ts
@@ -48,7 +48,7 @@ export type TutorialSummary = {
 
 export type StepActions = {
   commands?: string[];
-  commits: string[];
+  commits?: string[];
   files?: string[];
   watchers?: string[];
   filter?: string;


### PR DESCRIPTION
closes #40.

Treats the markdown as the source of truth. This means if a level/step isn't in the config, it will still build.

Allows for the new recommended way of labelling levels/steps:

In markdown: 
- Level: `## 1. Level one`
- Step: `### 1.1 A Label` (label is optional)

And in commits:
- `1 Level`
- `1.1 First step commit`
- `1.1S First step solution`
