### PR TITLE
breaking - changes to testRunner.setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@coderoad/cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coderoad/cli",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "A CLI to build the configuration file for Coderoad Tutorials",
   "keywords": [
     "coderoad",
@@ -15,8 +15,9 @@
     "url": "git+https://github.com/coderoad/coderoad-cli.git"
   },
   "license": "SEE LICENSE IN LICENSE.md",
-  "author": "Argemiro Neto",
+  "author": "Shawn McKay",
   "contributors": [
+    "Argemiro Neto",
     "Shawn McKay"
   ],
   "files": [

--- a/src/schema/meta.ts
+++ b/src/schema/meta.ts
@@ -47,6 +47,25 @@ export default {
         type: "string",
       },
     },
+    vscode_command_array: {
+      type: "array",
+      description:
+        "An array of VSCode commands that can be called using the vscode commands API.",
+      items: {
+        anyOf: [
+          {
+            type: "string",
+            description: "A VSCode command without params",
+          },
+          {
+            type: "array",
+            description: "A VSCode command with params",
+            minLength: 2,
+            maxLength: 2,
+          },
+        ],
+      },
+    },
     commit_array: {
       type: "array",
       description:
@@ -104,6 +123,9 @@ export default {
         },
         commands: {
           $ref: "#/definitions/command_array",
+        },
+        vscodeCommands: {
+          $ref: "#/definitions/vscode_command_array",
         },
         watchers: {
           type: "array",

--- a/src/schema/skeleton.ts
+++ b/src/schema/skeleton.ts
@@ -52,13 +52,13 @@ export default {
               description: "An optional folder for the test runner",
               examples: ["coderoad"],
             },
-            setup: {
-              $ref: "#/definitions/setup_action_without_commits",
-              description:
-                "Setup actions or commands used for setting up the test runner on tutorial launch",
-            },
           },
           required: ["command", "args"],
+        },
+        setup: {
+          $ref: "#/definitions/setup_action_without_commits",
+          description:
+            "Setup actions or commands used for setting up the test runner on tutorial launch",
         },
         repo: {
           type: "object",

--- a/src/schema/skeleton.ts
+++ b/src/schema/skeleton.ts
@@ -56,9 +56,20 @@ export default {
           required: ["command", "args"],
         },
         setup: {
-          $ref: "#/definitions/setup_action_without_commits",
+          type: "object",
           description:
-            "Setup actions or commands used for setting up the test runner on tutorial launch",
+            "Setup commits or commands used for setting up the test runner on tutorial launch",
+          properties: {
+            commits: {
+              $ref: "#/definitions/commit_array",
+            },
+            commands: {
+              $ref: "#/definitions/command_array",
+            },
+            vscodeCommands: {
+              $ref: "#/definitions/vscode_command_array",
+            },
+          },
         },
         repo: {
           type: "object",
@@ -84,10 +95,11 @@ export default {
           type: "object",
           description: "Configuration options for resetting a tutorial",
           properties: {
-            command: {
-              type: "string",
-              description: "An optional command to run on reset",
-              examples: ["npm install"],
+            commands: {
+              $ref: "#/definitions/command_array",
+            },
+            vscodeCommands: {
+              $ref: "#/definitions/vscode_command_array",
             },
           },
           additionalProperties: false,

--- a/src/schema/tutorial.ts
+++ b/src/schema/tutorial.ts
@@ -75,9 +75,20 @@ export default {
           required: ["command", "args"],
         },
         setup: {
-          $ref: "#/definitions/setup_action",
+          type: "object",
           description:
             "Setup commits or commands used for setting up the test runner on tutorial launch",
+          properties: {
+            commits: {
+              $ref: "#/definitions/commit_array",
+            },
+            commands: {
+              $ref: "#/definitions/command_array",
+            },
+            vscodeCommands: {
+              $ref: "#/definitions/vscode_command_array",
+            },
+          },
         },
         repo: {
           type: "object",
@@ -103,10 +114,11 @@ export default {
           type: "object",
           description: "Configuration options for resetting a tutorial",
           properties: {
-            command: {
-              type: "string",
-              description: "An optional command to run on reset",
-              examples: ["npm install"],
+            commands: {
+              $ref: "#/definitions/command_array",
+            },
+            vscodeCommands: {
+              $ref: "#/definitions/vscode_command_array",
             },
           },
           additionalProperties: false,

--- a/src/schema/tutorial.ts
+++ b/src/schema/tutorial.ts
@@ -71,13 +71,13 @@ export default {
               description: "An optional folder for the test runner",
               examples: ["coderoad"],
             },
-            setup: {
-              $ref: "#/definitions/setup_action",
-              description:
-                "Setup commits or commands used for setting up the test runner on tutorial launch",
-            },
           },
           required: ["command", "args"],
+        },
+        setup: {
+          $ref: "#/definitions/setup_action",
+          description:
+            "Setup commits or commands used for setting up the test runner on tutorial launch",
         },
         repo: {
           type: "object",

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -153,8 +153,8 @@ export function parse(params: ParseParams): any {
   // add init commits
   if (params.commits.INIT && params.commits.INIT.length) {
     // @ts-ignore
-    parsed.config.testRunner.setup = {
-      ...(parsed.config?.testRunner?.setup || {}),
+    parsed.config.setup = {
+      ...(parsed.config?.setup || {}),
       commits: params.commits.INIT,
     };
   }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -74,14 +74,10 @@ async function validate(args: string[]) {
       await cherryPick(commits.INIT);
 
       // run commands
-      if (skeleton.config?.testRunner?.setup?.commands) {
+      if (skeleton.config?.setup?.commands) {
         console.info("-- Running commands...");
 
-        await runCommands(
-          skeleton.config?.testRunner?.setup?.commands,
-          // add optional setup directory
-          skeleton.config?.testRunner?.directory
-        );
+        await runCommands(skeleton.config?.setup?.commands);
       }
     }
 

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -987,9 +987,9 @@ Description.
               tap: "--reporter=mocha-tap-reporter",
             },
             directory: "coderoad",
-            setup: {
-              commands: [],
-            },
+          },
+          setup: {
+            commands: [],
           },
           appVersions: {
             vscode: ">=0.7.0",
@@ -1026,9 +1026,9 @@ Description.
               tap: "--reporter=mocha-tap-reporter",
             },
             directory: "coderoad",
-            setup: {
-              commands: [],
-            },
+          },
+          setup: {
+            commands: [],
           },
           repo: {
             uri: "https://path.to/repo",
@@ -1101,9 +1101,9 @@ Description.
               tap: "--reporter=mocha-tap-reporter",
             },
             directory: "coderoad",
-            setup: {
-              commits: ["abcdef1", "123456789"],
-            },
+          },
+          setup: {
+            commits: ["abcdef1", "123456789"],
           },
           repo: {
             uri: "https://path.to/repo",

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -999,7 +999,7 @@ Description.
             branch: "aBranch",
           },
           reset: {
-            command: "some command",
+            commands: ["some command"],
           },
           dependencies: [
             {
@@ -1035,7 +1035,7 @@ Description.
             branch: "aBranch",
           },
           reset: {
-            command: "some command",
+            commands: ["some command"],
           },
           dependencies: [
             {

--- a/tests/skeleton.test.ts
+++ b/tests/skeleton.test.ts
@@ -8,14 +8,15 @@ const validJson = {
   config: {
     testRunner: {
       directory: "coderoad",
-      setup: {
-        commands: [],
-      },
+
       args: {
         filter: "--grep",
         tap: "--reporter=mocha-tap-reporter",
       },
       command: "./node_modules/.bin/mocha",
+    },
+    setup: {
+      commands: [],
     },
     repo: {
       uri: "http://github.com/somePath/toRepo.git",

--- a/tests/tutorial.test.ts
+++ b/tests/tutorial.test.ts
@@ -13,10 +13,10 @@ const validJson: Partial<T.Tutorial> = {
         tap: "tap",
       },
       directory: "coderoad",
-      setup: {
-        commits: ["abcdef1"],
-        commands: ["npm install"],
-      },
+    },
+    setup: {
+      commits: ["abcdef1"],
+      commands: ["npm install"],
     },
     repo: {
       uri: "https://github.com/some-repo.git",

--- a/typings/tutorial.d.ts
+++ b/typings/tutorial.d.ts
@@ -10,6 +10,7 @@ export type TutorialConfig = {
   repo: TutorialRepo;
   dependencies?: TutorialDependency[];
   reset?: ConfigReset;
+  setup?: StepActions;
 };
 
 /** Logical groupings of tasks */
@@ -69,7 +70,6 @@ export interface TestRunnerConfig {
   command: string;
   args: TestRunnerArgs;
   directory?: string;
-  setup?: StepActions;
 }
 
 export interface TutorialRepo {


### PR DESCRIPTION
Corresponds to https://github.com/coderoad/coderoad-vscode/pull/417.

BREAKING CHANGE, see notes linked above.

- Supports config.setup (instead of config.testRunner.setup)
- Supports reset.commands
- Limits commands in schema check to valid commands

This PR will be released with coderoad-vscode v0.13 goes out.

Signed-off-by: shmck <shawn.j.mckay@gmail.com>