### PR TITLE
eat error if remote exists

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -58,7 +58,9 @@ async function validate (args: string[]) {
     const tempGit: SimpleGit = gitP(tmpDir)
 
     await tempGit.init()
-    await tempGit.addRemote('origin', skeleton.config.repo.uri)
+    await tempGit
+      .addRemote('origin', skeleton.config.repo.uri)
+      .catch(console.warn)
     await tempGit.fetch('origin', skeleton.config.repo.branch)
     // no js cherry pick implementation
     const cherryPick = createCherryPick(tmpDir)


### PR DESCRIPTION
Possibly a fix for #72.

Converts throwing "remote exists" error into a warning.

Signed-off-by: shmck <shawn.j.mckay@gmail.com>