### PR TITLE
feat: add support for continue config

### DIFF
--- a/src/schema/skeleton.ts
+++ b/src/schema/skeleton.ts
@@ -97,6 +97,19 @@ export default {
           additionalProperties: false,
           required: ["uri", "branch"],
         },
+        continue: {
+          type: "object",
+          description: "Configuration options for continuing a tutorial",
+          properties: {
+            commands: {
+              $ref: "#/definitions/command_array",
+            },
+            vscodeCommands: {
+              $ref: "#/definitions/vscode_command_array",
+            },
+          },
+          additionalProperties: false,
+        },
         reset: {
           type: "object",
           description: "Configuration options for resetting a tutorial",
@@ -163,6 +176,11 @@ export default {
                   type: "boolean",
                   description:
                     "An event triggered on tutorial startup. Sends tutorialId",
+                },
+                continue: {
+                  type: "boolean",
+                  description:
+                    "An event triggered when continuing a tutorial. Sends tutorialId",
                 },
                 reset: {
                   type: "boolean",

--- a/src/schema/tutorial.ts
+++ b/src/schema/tutorial.ts
@@ -116,6 +116,19 @@ export default {
           additionalProperties: false,
           required: ["uri", "branch"],
         },
+        continue: {
+          type: "object",
+          description: "Configuration options for continuing a tutorial",
+          properties: {
+            commands: {
+              $ref: "#/definitions/command_array",
+            },
+            vscodeCommands: {
+              $ref: "#/definitions/vscode_command_array",
+            },
+          },
+          additionalProperties: false,
+        },
         reset: {
           type: "object",
           description: "Configuration options for resetting a tutorial",
@@ -182,6 +195,11 @@ export default {
                   type: "boolean",
                   description:
                     "An event triggered on tutorial startup. Sends tutorialId",
+                },
+                continue: {
+                  type: "boolean",
+                  description:
+                    "An event triggered when continuing a tutorial. Sends tutorialId",
                 },
                 reset: {
                   type: "boolean",

--- a/src/schema/tutorial.ts
+++ b/src/schema/tutorial.ts
@@ -316,5 +316,5 @@ export default {
     },
   },
   additionalProperties: false,
-  required: ["version", "summary", "config", "levels"],
+  required: ["id", "version", "summary", "config", "levels"],
 };

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -144,6 +144,7 @@ export function parse (params: ParseParams): any {
   const mdContent: TutorialFrame = parseMdContent(params.text + '\n\n')
 
   const parsed: Partial<T.Tutorial> = {
+    id: params.skeleton.id,
     version: params.skeleton.version,
     summary: mdContent.summary,
     config: params.skeleton.config || {},


### PR DESCRIPTION
Looks like continue commands were added to the extension but not the CLI tools. So you will get an error when trying to build if you add them to the yaml. This should fix that. Seems to work.